### PR TITLE
correct property prefix name

### DIFF
--- a/charts/zeebe-tasklist-helm/templates/configmap.yaml
+++ b/charts/zeebe-tasklist-helm/templates/configmap.yaml
@@ -6,7 +6,7 @@ data:
   application.yml: |
     # Tasklist configuration file
 
-    zeebe.tasklist:
+    camunda.tasklist:
       # Set Tasklist username and password.
       # If user with <username> does not exists it will be created.
       # Default: demo/demo


### PR DESCRIPTION
Hi ! the image repository changed seems to have affected  property name in the configmap.yaml. 
These two images are not the same even though they're the same version ？